### PR TITLE
Michael Sheely replace_with and MyRc

### DIFF
--- a/rc/src/lib.rs
+++ b/rc/src/lib.rs
@@ -19,6 +19,7 @@ impl<T> MyRc<T> {
     unsafe {
       if *self.count == 1 {
         let t: T = ptr::read(self.data);
+        *self.count += 1;
         Ok(t)
       } else {
         Err(self)
@@ -48,11 +49,10 @@ impl<T> Clone for MyRc<T> {
 impl<T> Drop for MyRc<T> {
   fn drop(&mut self) {
     unsafe {
-      if *self.count == 1 {
+      *self.count -= 1;
+      if *self.count == 0 {
         Box::from_raw(self.data);   // convert back to boxes
         Box::from_raw(self.count);  // so destructors will run
-      } else {
-        *self.count -= 1;
       }
     }
   }

--- a/rc/src/lib.rs
+++ b/rc/src/lib.rs
@@ -19,6 +19,7 @@ impl<T> MyRc<T> {
     unsafe {
       if *self.count == 1 {
         let t: T = ptr::read(self.data);
+        // This will prevent us from dropping the data twice
         *self.count += 1;
         Ok(t)
       } else {
@@ -49,8 +50,8 @@ impl<T> Clone for MyRc<T> {
 impl<T> Drop for MyRc<T> {
   fn drop(&mut self) {
     unsafe {
-      *self.count -= 1;
-      if *self.count == 0 {
+      *self.count -= 1;         // one fewer reference
+      if *self.count == 0 {     // if it was the last one:
         Box::from_raw(self.data);   // convert back to boxes
         Box::from_raw(self.count);  // so destructors will run
       }

--- a/rc/src/lib.rs
+++ b/rc/src/lib.rs
@@ -1,29 +1,61 @@
-
 use std::ops::Deref;
+use std::ptr;
 
-struct MyRC<T> {
-  data: Box<T>
+pub struct MyRc<T> {
+  data: *mut T,
+  count: *mut usize,
 }
 
-impl<T> MyRC<T> {
-  fn new(t: T) -> MyRC<T> {
-      MyRC{data: Box::new(t)}
+impl<T> MyRc<T> {
+  pub fn new(t: T) -> MyRc<T> {
+      let data_box  = Box::new(t);
+      let count_box = Box::new(1);  // one reference to the underlying data
+      let data_ptr  = Box::into_raw(data_box);  // now we own the heap data
+      let count_ptr = Box::into_raw(count_box);
+      MyRc{data: data_ptr, count: count_ptr}
   }
 
-  fn consume(self) -> Result<T, MyRC<T> > {
-      Ok(*self.data)
+  pub fn consume(self) -> Result<T, MyRc<T> > {
+    unsafe {
+      if *self.count == 1 {
+        let t: T = ptr::read(self.data);
+        Ok(t)
+      } else {
+        Err(self)
+      }
+    }
   }
+
 }
 
-impl<T> Deref for MyRC<T> {
+impl<T> Deref for MyRc<T> {
     type Target = T;
     fn deref(&self) -> &T {
-        &self.data
+        unsafe {
+          &(*self.data)
+        }
     }
 }
-impl<T> Clone for MyRC<T> {
-    fn clone(&self) -> MyRC<T> {
-        MyRC{data: self.data}
+
+impl<T> Clone for MyRc<T> {
+    fn clone(&self) -> MyRc<T> {
+        unsafe {
+          *self.count += 1;  // there is now another reference
+          MyRc{data: self.data, count: self.count}
+        }
     }
+}
+
+impl<T> Drop for MyRc<T> {
+  fn drop(&mut self) {
+    unsafe {
+      if *self.count == 1 {
+        let boxed_data = Box::from_raw(self.data);
+        let boxed_counter = Box::from_raw(self.count);
+      } else {
+        *self.count -= 1;
+      }
+    }
+  }
 }
 

--- a/rc/src/lib.rs
+++ b/rc/src/lib.rs
@@ -1,0 +1,29 @@
+
+use std::ops::Deref;
+
+struct MyRC<T> {
+  data: Box<T>
+}
+
+impl<T> MyRC<T> {
+  fn new(t: T) -> MyRC<T> {
+      MyRC{data: Box::new(t)}
+  }
+
+  fn consume(self) -> Result<T, MyRC<T> > {
+      Ok(*self.data)
+  }
+}
+
+impl<T> Deref for MyRC<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.data
+    }
+}
+impl<T> Clone for MyRC<T> {
+    fn clone(&self) -> MyRC<T> {
+        MyRC{data: self.data}
+    }
+}
+

--- a/rc/src/lib.rs
+++ b/rc/src/lib.rs
@@ -25,7 +25,6 @@ impl<T> MyRc<T> {
       }
     }
   }
-
 }
 
 impl<T> Deref for MyRc<T> {
@@ -50,8 +49,8 @@ impl<T> Drop for MyRc<T> {
   fn drop(&mut self) {
     unsafe {
       if *self.count == 1 {
-        let boxed_data = Box::from_raw(self.data);
-        let boxed_counter = Box::from_raw(self.count);
+        Box::from_raw(self.data);   // convert back to boxes
+        Box::from_raw(self.count);  // so destructors will run
       } else {
         *self.count -= 1;
       }

--- a/replace_with/src/lib.rs
+++ b/replace_with/src/lib.rs
@@ -1,0 +1,5 @@
+
+pub fn replace_with<T, F: FnOnce(T) -> T>(t : &mut T, f: F) {
+
+}
+

--- a/replace_with/src/lib.rs
+++ b/replace_with/src/lib.rs
@@ -1,5 +1,11 @@
+use std::ptr;
+use std::fmt;
 
-pub fn replace_with<T, F: FnOnce(T) -> T>(t : &mut T, f: F) {
-
+pub fn replace_with<T: fmt::Debug, F: FnOnce(T) -> T>(t : &mut T, f: F) {
+    let t_ptr = t as *mut T;
+    unsafe { 
+        let new_int = ptr::read(t_ptr);
+        ptr::write(t_ptr, f(new_int));
+    }
 }
 


### PR DESCRIPTION
Finished assignment.  (Had extension until Friday).

Got help from Jackson Warely and Adam Dunlap.

The increment of `count` within `consume` seemed kind of like a hack, but I think it should be fine since it will only happen if we have the very last reference to the data.

I tried to make it a little more elegant by adding a `consumed : bool` data member to the MyRc which would keep track of whether or not the reference counter's underlying data has been consumed (so that the destructor can check this `bool` before calling `from_raw` on the raw `data` pointer).  However, when I tried to implement this, rust was angry about my attempt to set the bool within the struct, but I couldn't figure out how to change it's value (the `consume` function takes self by move rather than by `&mut`, so it didn't allow me to mutate the `bool` contained -- thus I just kept the version that adds one).

I kept running into issues like 
```
22 |         let t: T = *self.data;
   |             -      ^^^^^^^^^^ cannot move out of dereference of raw pointer
   |             |
```
and I'm not sure I understand why this shouldn't be allowed from the perspective of the rust memory model.  It is in an unsafe block, so why won't it let me construct a `T` out of the data, and rather force me to use `ptr::read`?  I thought that only references had ownership, I didn't know that raw pointers would as well. I'm probably missing something here.